### PR TITLE
Hand-tweaked modification to mico.urdf to make it match reality

### DIFF
--- a/ada_description/robots/mico.urdf
+++ b/ada_description/robots/mico.urdf
@@ -141,7 +141,7 @@
     type="revolute">
     <origin
       xyz="0 -0.00175 0.11875"
-      rpy="1.5708 0 3.1416" />
+      rpy="1.5708 -0.22 3.1416" />
     <parent
       link="Shoulder_Link" />
     <child


### PR DESCRIPTION
As per https://github.com/personalrobotics/ada/issues/22 the rotation of j2 does not match the physical robot as verified though rviz and my own urdf loader.

This adds a slight (0.22 radian = 12 deg) rotation to j2 to make it line up.
