### PR TITLE
Fixed return type of ExecuteTrajectory

### DIFF
--- a/adapy/src/adapy/adarobot.py
+++ b/adapy/src/adapy/adarobot.py
@@ -220,7 +220,6 @@ class ADARobot(Robot):
         else:
             try:
                 traj_future.result(timeout)
-                print 'ksadjfksjadfjksadfjksadfjsad'
                 return traj
             except TrajectoryExecutionFailed as e:
                 logger.exception('Trajectory execution failed.')


### PR DESCRIPTION
Fixes the issue pointed out here:
https://github.com/personalrobotics/ada/issues/43#i
By using the fix suggested by mkoval.

Tested on ada, no more crashes when executing trajectories!
