### PR TITLE
No more crashes when planning to current position

### DIFF
--- a/adapy/src/adapy/adarobot.py
+++ b/adapy/src/adapy/adarobot.py
@@ -198,6 +198,7 @@ class ADARobot(Robot):
             return Robot.ExecuteTrajectory(self, traj, defer=defer, timeout=timeout,
                                            **kwargs)
 
+
         # Check that the current configuration of the robot matches the
         # initial configuration specified by the trajectory.
         if not prpy.util.IsAtTrajectoryStart(self, traj):


### PR DESCRIPTION
Resolves #44 (and identical bug when planning to the current position) by simply checking if we are at the current position. If so, won't try to execute.
