### PR TITLE
added urdf frames. switched color and depth

### DIFF
--- a/ada_description/robots/mico.urdf
+++ b/ada_description/robots/mico.urdf
@@ -280,7 +280,7 @@
     </collision>
   </link>
   <link
-    name="Camera_RGB_Frame">
+    name="Camera_Depth_Frame">
     <inertial>
       <origin
         xyz="0 0 0"
@@ -304,8 +304,36 @@
     <parent
       link="mico_link_hand" />
     <child
+      link="Camera_Depth_Frame" />
+  </joint>
+  <joint
+    name="Camera_Depth_Joint" type = "fixed">
+    <origin
+      xyz="0.045 -0.015 -0.03"
+      rpy="0 0.000 0" />
+    <parent
+      link="Camera_Depth_Frame" />
+    <child
       link="Camera_RGB_Frame" />
   </joint>
+   <link
+    name="Camera_RGB_Frame">
+        <inertial>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <mass
+        value="0.05" />
+      <inertia
+        ixx="0"
+        ixy="0"
+        ixz="0"
+        iyy="0"
+        iyz="0"
+        izz="0" />
+    </inertial>
+  </link>
+  
   <link
     name="Camera_Collision_Frame">
     <inertial>


### PR DESCRIPTION
This adds a frame for the depth image and color image to the URDF.

![image](http://i.imgur.com/tyTbCBu.png)
# Important notes
- The numbers were pulled out of thin air. I didn't touch the TF frame for the depth image, and just eyeballed the frame for the RGB image.
- I switched the RGB and depth frames. For some reason "Camera_RGB_Frame" was aligned with the depth image on the structure io, and there was no frame at all for the real RGB frame from the ueye sensor.
